### PR TITLE
Path matches validator

### DIFF
--- a/src/main/java/com/openkm/automation/validation/PathMatches.java
+++ b/src/main/java/com/openkm/automation/validation/PathMatches.java
@@ -1,0 +1,57 @@
+/**
+ * OpenKM, Open Document Management System (http://www.openkm.com)
+ * Copyright (c) 2017  Gustavo del Dago
+ * <p>
+ * No bytes were intentionally harmed during the development of this application.
+ * <p>
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.openkm.automation.validation;
+
+import com.openkm.api.OKMRepository;
+import com.openkm.automation.AutomationUtils;
+import com.openkm.automation.Validation;
+import com.openkm.dao.bean.NodeDocument;
+import com.openkm.dao.bean.NodeFolder;
+import com.openkm.dao.bean.NodeMail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+public class PathMatches implements Validation {
+	private static Logger log = LoggerFactory.getLogger(NameContains.class);
+
+	@Override
+	public boolean isValid(HashMap<String, Object> env, Object... params) {
+		try {
+			String regEx = AutomationUtils.getString(0, params);
+			String path = AutomationUtils.getParentPath(env);
+			
+			if (path.matches(regEx)) {
+				return true;
+			} else {
+				return false;
+			}
+		} catch (Exception e) {
+			log.error(e.getMessage(), e);
+		}
+
+		return false;
+	}
+	
+}
+

--- a/src/main/resources/extensions/automation.sql
+++ b/src/main/resources/extensions/automation.sql
@@ -10,6 +10,7 @@ INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_
 INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES ('post', 'com.openkm.automation.validation.HasCategory', 'HasCategory', 'validation', 'text', 'okm:folder', 'String', '', '', '');
 INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES ('post', 'com.openkm.automation.validation.UserHasRole', 'UserHasRole', 'validation', 'text', '', 'Keyword', '', '', '');
 INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES ('pre', 'com.openkm.automation.validation.UserHasRole', 'UserHasRole', 'validation', 'text', '', 'Keyword', '', '', '');
+INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES ('post','com.openkm.automation.validation.PathMatches', 'PathMatches', 'validation', 'text', '', 'String', '', '', '');
 
 -- ACTIONS
 INSERT INTO OKM_AUTO_METADATA (AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES ('post', 'com.openkm.automation.action.AddKeyword', 'AddKeyword', 'action', 'text', '', 'Keyword', '', '', '');
@@ -44,6 +45,7 @@ INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GRO
 INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES (HIBERNATE_SEQUENCE.nextval, 'post', 'com.openkm.automation.validation.HasCategory', 'HasCategory', 'validation', 'text', 'okm:folder', 'String', '', '', '');
 INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES (HIBERNATE_SEQUENCE.nextval, 'post', 'com.openkm.automation.validation.HasKeyword', 'UserHasRole', 'validation', 'text', '', 'Keyword', '', '', '');
 INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES (HIBERNATE_SEQUENCE.nextval, 'pre', 'com.openkm.automation.validation.HasKeyword', 'UserHasRole', 'validation', 'text', '', 'Keyword', '', '', '');
+INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES (HIBERNATE_SEQUENCE.nextval, 'post', 'com.openkm.automation.validation.PathMatches', 'PathMatches', 'validation', 'text', 'okm:folder', 'String', '', '', '');
 
 -- ACTIONS
 INSERT INTO OKM_AUTO_METADATA (AMD_ID, AMD_AT, AMD_CLASS_NAME, AMD_NAME, AMD_GROUP, AMD_TYPE00, AMD_SRC00, AMD_DESC00, AMD_TYPE01, AMD_SRC01, AMD_DESC01) VALUES (HIBERNATE_SEQUENCE.nextval, 'post', 'com.openkm.automation.action.AddKeyword', 'AddKeyword', 'action', 'text', '', 'Keyword', '', '', '');


### PR DESCRIPTION
Estimados.

Esta rama incorpora un nuevo tipo de _validator_ denominado _PathMatches_.
A continuación comparto una breve descripción de la funcionalidad y un modo de uso que pretende ilustrar su utilidad. Considero que se trata de una característica que podría resultar interesnate para otros usuarios de la versión comunitaria.
Quedo atento a vuestros comentarios.
Saludos,
Gustavo

**Descripción**
El validator recibe un parámetro de tipo _texto_ en el que podremos escribir una _expresión regular_ (respetando la sintáxis de las expresiones regulares del lenguaje JAVA).
De este modo podremos programar reglas de automatización que apliquen en distintos nodos de la taxonomía en la medida que seamos capaces de escribir la expresión regular correspondiente.

**Escenario de uso** (a modo de ejemplo)
Es posible que tengamos intención de realizar determinadas acciones (por ejemplo agregar un _grupo de propiedades_) a documentos que se alojen en directorios con determinados nombres sin importar en que rama de la _taxonomía_ se encuntren. Actualmente deberémos programar (y mantener) tantas _reglas de automatización_ como directorios donde se quieran realizar las acciones. 
Utiliando _PathMatches_ podremos programar (y mantener) una única regla que se aplicará a todos los directorios cuyo nombre cumpla con la expresión regular dada.
 