### PR TITLE
LDAP integration: add support for operational attributes, by retrieving attributes by name.

### DIFF
--- a/src/main/java/com/openkm/principal/LdapPrincipalAdapter.java
+++ b/src/main/java/com/openkm/principal/LdapPrincipalAdapter.java
@@ -272,6 +272,9 @@ public class LdapPrincipalAdapter implements PrincipalAdapter {
 				ctx = new InitialDirContext(env);
 				SearchControls searchCtls = new SearchControls();
 				searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+				if (!attribute.equals("")) {
+					searchCtls.setReturningAttributes(new String[] {attribute});
+				}
 
 				for (String searchBase : searchBases) {
 					NamingEnumeration<SearchResult> results = ctx.search(searchBase, searchFilter, searchCtls);


### PR DESCRIPTION
Hi,
Currently, _ldapSearch_ method in _LdapPrincipalAdapter_ does not retrieve operational attributes.
This is a problem when integrating OpenKM with OpenLDAP, in which _memberOf_ is operational attribute.
According to [java documentation](https://docs.oracle.com/javase/8/docs/api/javax/naming/directory/DirContext.html): "In order to retrieve operational attributes, you must name them explicitly", so my proposition is to retrieve attributes by name.

For example, in the following OpenLDAP structure, 'memberOf' attributes are operational attributes.

```
dc=com
    dc=some
        ou=roles
            cn=ROLE_ADMIN
		objectClass=groupOfNames
                member=uid=user1,ou=users,dc=some,dc=com
                member=uid=user2,ou=users,dc=some,dc=com
            cn=ROLE_USER
		objectClass=groupOfNames
                member=uid=user2,ou=users,dc=some,dc=com
        ou=users
            uid=user1
                mail=user@mail.com
                cn=User Name 1
		memberOf=cn=ROLE_ADMIN,ou=roles,dc=some,dc=com
            uid=user2
                mail=user2@mail.com
                cn=User Name 2
		memberOf=cn=ROLE_ADMIN,ou=roles,dc=some,dc=com
		memberOf=cn=ROLE_USER,ou=roles,dc=some,dc=com
```
This configuration currently does not work with OpenLDAP, because memberOf attributes are not retrieved.

> principal.ldap.roles.by.user.attribute: memberOf
> principal.ldap.roles.by.user.search.base: ou=users,dc=some,dc=com
> principal.ldap.roles.by.user.search.filter: (&(objectClass=inetOrgPerson)(uid={0})) 

Please consider introducing this change, thanks.