### PR TITLE
OpenLDAP integration: enhance support for distinguished names in getUsersByRole.

### DIFF
--- a/src/main/java/com/openkm/core/Config.java
+++ b/src/main/java/com/openkm/core/Config.java
@@ -190,6 +190,7 @@ public class Config {
 	public static final String PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_SEARCH_BASE = "principal.ldap.users.by.role.search.base";
 	public static final String PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_SEARCH_FILTER = "principal.ldap.users.by.role.search.filter";
 	public static final String PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE = "principal.ldap.users.by.role.attribute";
+	public static final String PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN = "principal.ldap.users.by.role.attribute.contains.dn";
 
 	public static final String PROPERTY_PRINCIPAL_LDAP_ROLES_BY_USER_SEARCH_BASE = "principal.ldap.roles.by.user.search.base";
 	public static final String PROPERTY_PRINCIPAL_LDAP_ROLES_BY_USER_SEARCH_FILTER = "principal.ldap.roles.by.user.search.filter";
@@ -467,6 +468,7 @@ public class Config {
 	public static String PRINCIPAL_LDAP_USERNAME_SEARCH_BASE; // ou=people,dc=openkm,dc=com
 	public static String PRINCIPAL_LDAP_USERNAME_SEARCH_FILTER; // (&(objectClass=posixAccount)(!(objectClass=gosaUserTemplate)))
 	public static String PRINCIPAL_LDAP_USERNAME_ATTRIBUTE; // displayName
+	public static boolean PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN;
 
 	public static String PRINCIPAL_LDAP_MAIL_SEARCH_BASE; // uid={0},ou=people,dc=openkm,dc=com
 	public static String PRINCIPAL_LDAP_MAIL_SEARCH_FILTER; // (&(objectClass=inetOrgPerson)(mail=*))
@@ -928,6 +930,8 @@ public class Config {
 			values.put(PROPERTY_PRINCIPAL_LDAP_USERNAME_SEARCH_FILTER, PRINCIPAL_LDAP_USERNAME_SEARCH_FILTER);
 			PRINCIPAL_LDAP_USERNAME_ATTRIBUTE = ConfigDAO.getString(PROPERTY_PRINCIPAL_LDAP_USERNAME_ATTRIBUTE, "");
 			values.put(PROPERTY_PRINCIPAL_LDAP_USERNAME_ATTRIBUTE, PRINCIPAL_LDAP_USERNAME_ATTRIBUTE);
+			PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN = ConfigDAO.getBoolean(PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN, false);
+			values.put(PROPERTY_PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN, Boolean.toString(PRINCIPAL_LDAP_USERS_BY_ROLE_ATTRIBUTE_CONTAINS_DN));
 
 			PRINCIPAL_LDAP_MAIL_SEARCH_BASE = ConfigDAO.getString(PROPERTY_PRINCIPAL_LDAP_MAIL_SEARCH_BASE, "");
 			values.put(PROPERTY_PRINCIPAL_LDAP_MAIL_SEARCH_BASE, PRINCIPAL_LDAP_MAIL_SEARCH_BASE);


### PR DESCRIPTION
**NOTE:** Changes in this pull request are largely copied from [patch authored by Martin.povolny.yuh](https://www.openkm.com/wiki/index.php/LDAP_and_Active_Directory_uniqueMember_user_examples)

Currently, attribute configured in _principal.ldap.users.by.role.attribute_ may contain distinguished names, but only if they start with _'cn='_ or _'CN='_, as those are the two strings indicating FQDN in _ldapSearch_.
```
// If FQDN get only main part
if (value.startsWith("CN=") || value.startsWith("cn=")) {
		String cn = value.substring(3, value.indexOf(','));
		log.debug("FQDN: {}, CN: {}", value, cn);
		al.add(cn);
} else {
		al.add(value);
}
```

This patch introduces new property _principal.ldap.users.by.role.attribute.contains.dn_. If set to true, _getUsersByRole_ will make additional _ldapSearch_ call to get user name based on distinguished name value from _principal.ldap.users.by.role.attribute_.


I am trying to integrate with OpenLDAP server, with groups of _groupOfNames_ or _groupOfUniqueNames_ type, both of which require use of distinguished names as their attribute values. Unfortunately, in my case distinguished names start with _'uid='_.

Example OpenLDAP structure:
```
dc=com
    dc=some
        ou=roles
            cn=ROLE_ADMIN
		objectClass=groupOfNames
                member=uid=user1,ou=users,dc=some,dc=com
                member=uid=user2,ou=users,dc=some,dc=com
            ou=sub
                cn=ROLE_USER
		    objectClass=groupOfNames
                    member=uid=user2,ou=users,dc=some,dc=com
        ou=users
            uid=user1
                mail=user@mail.com
                cn=User Name 1
		memberOf=cn=ROLE_ADMIN,ou=roles,dc=some,dc=com
            uid=user2
                mail=user2@mail.com
                cn=User Name 2
		memberOf=cn=ROLE_ADMIN,ou=roles,dc=some,dc=com
		memberOf=cn=ROLE_USER,ou=sub,ou=roles,dc=some,dc=com
```
		
Example configuration, that currently does not work:

> principal.ldap.users.by.role.attribute: member
> principal.ldap.users.by.role.search.base: ou=roles,dc=some,dc=com
> principal.ldap.users.by.role.search.filter: (&(objectClass=groupOfNames)(cn={0}))

I do not know if there is other way to configure OpenKM to work with structure as above.
It seems to me, that only groups of type _posixGroup_ are currently supported when integrating with OpenLDAP. This change, together with #146, would allow OpenKM to work with _groupOfNames_,  _groupOfUniqueNames_  and potentially other types of groups in different LDAP flavors. 


