### PR TITLE
Fix node locking for webdav

### DIFF
--- a/src/main/java/com/openkm/dao/NodeDocumentDAO.java
+++ b/src/main/java/com/openkm/dao/NodeDocumentDAO.java
@@ -1156,7 +1156,10 @@ public class NodeDocumentDAO {
 			nDoc.setLock(nLock);
 			nDoc.setLocked(true);
 		} else {
-			throw new LockException("Node already locked");
+			NodeLock nLock = nDoc.getLock();
+			if (!nLock.getOwner().equals(user)) {
+				throw new LockException("Node already locked by another user");
+			}
 		}
 	}
 


### PR DESCRIPTION
This makes the locking only break writing a file if it's locked to somebody else.  This workaround allows writing files from Windows over WebDav

NOTE: Previously provided this patch at https://forum.openkm.com/viewtopic.php?p=41311&sid=8a28cda917b66723aeaf7423745899c5#p41311